### PR TITLE
Fix watching scripts inside .asars

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,11 +80,21 @@ function watchScripts() {
 
 	for (var i = 0; i < scripts.length; i++) {
 		var uri = url.parse(scripts[i].src);
-		watchFile(uri.pathname);
+		watchScript(uri.pathname);
 	}
 
 	for (var filepath in require.cache) {
-		watchFile(filepath);
+		watchScript(filepath);
 	}
 }
 
+var splitCache = {};
+function watchScript(filepath) {
+	if (~filepath.indexOf('.asar')) {
+		filepath = filepath.split('.asar')[0] + '.asar';
+	}
+	if (!splitCache[filepath]) {
+		splitCache[filepath] = true;
+		watchFile(filepath);
+	}
+}


### PR DESCRIPTION
In more recent versions of that atom-shell binaries downloaded from npm (https://www.npmjs.com/package/atom-shell) core atom shell js files are archived in a `.asar` file. This is also possible in other atom-shell apps as well (or in packages, more importantly). This breaks atom-watcher with an ENOTDIR error, since it tries to treat the asar as a directory (which is how require works). This change simply watches the asar (I don't know if it's possible for someone to do so, but just in case there is a nested asar, it still just watches the root, since thats the actual 'file' on the system). It also caches to make sure they don't get duplicate watches (since by default there are definitely several duplicates after just trimming to the asar). 
