### PR TITLE
Only scripts tag with a src attribute should be watched

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,10 @@ function watchScripts() {
 	var scripts = document.querySelectorAll('script');
 
 	for (var i = 0; i < scripts.length; i++) {
-		var uri = url.parse(scripts[i].src);
-		watchScript(uri.pathname);
+		if (scripts[i].src) {
+			var uri = url.parse(scripts[i].src);
+			watchScript(uri.pathname);
+		}
 	}
 
 	for (var filepath in require.cache) {


### PR DESCRIPTION
Inline scripts in the form of

```
<script> doSomeMagic(); </script>
```

were causing an error.
